### PR TITLE
Fix gradient calculation for quantization lower bound

### DIFF
--- a/nncf/quantization/cuda/functions_cuda_kernel.cu
+++ b/nncf/quantization/cuda/functions_cuda_kernel.cu
@@ -285,7 +285,7 @@ __global__ void q_scale_per_activation_channel_cuda_backward_kernel(
     scalar_t sum_range = 0, sum_low = 0;
     scalar_t output, val_grad_input_range, val_grad_input_low;
     scalar_t alpha = level_low / level_high;
-    scalar_t range_low = (*input_low) + (*input_range) * alpha;
+    scalar_t range_low = (*input_low);
     scalar_t range_high = (*input_low) + (*input_range);
     scalar_t reverted_range = 1 / (*input_range);
 

--- a/tests/quantization/test_functions.py
+++ b/tests/quantization/test_functions.py
@@ -20,7 +20,7 @@ from nncf.quantization.quantize_functions import asymmetric_quantize, symmetric_
 from nncf.utils import sum_like
 from tests.helpers import get_grads, check_equal
 
-EPS = 1
+EPS = 1e-6
 
 
 class ReferenceQuantize:
@@ -38,7 +38,7 @@ class ReferenceQuantize:
 
     @staticmethod
     def backward(grad_output, input_, input_low, input_range, output, level_low, level_high, range_sign):
-        mask_hi = (input_ > input_low + input_range).astype(input_.dtype)
+        mask_hi = (input_ > (input_low + input_range)).astype(input_.dtype)
         mask_lo = (input_ < input_low).astype(input_.dtype)
 
         mask_in = 1 - mask_hi - mask_lo
@@ -94,7 +94,7 @@ def _seed():
 
 
 def generate_input(input_size):
-    return 2 * np.random.random_sample(input_size) - 1
+    return 1.0 * (2 * np.random.random_sample(input_size) - 1)
 
 
 def get_test_data(data_list, is_cuda=False, is_backward=False, is_fp16=False):
@@ -151,7 +151,9 @@ class TestParametrized:
             assert scale_mode in ["single_scale", "per_channel_scale"]
 
             def calc_scale(input_):
-                return min(abs(input_.min()), abs(input_.max())) - input_.mean() / 4
+                # Should generate a scale that is 1/2 of the input data span,
+                # to test the out-of-bounds gradient calculation
+                return (min(abs(input_.min()), abs(input_.max())) - input_.mean()) / 4
 
             if scale_mode == "single_scale":
                 return np.array([calc_scale(input_)])
@@ -251,17 +253,17 @@ class TestParametrized:
             check_outputs_for_quantization_functions(ref_output, test_value, is_fp16)
             check_outputs_for_quantization_functions(ref_grads, test_grads, is_fp16)
 
-    @pytest.mark.parametrize("is_negative_range", (True, False), ids=('range<0', 'range>0'))
     class TestAsymmetric:
         @staticmethod
-        def generate_range(input_, is_negative_range, scale_mode, is_weights, is_fp16):
+        def generate_range(input_, scale_mode, is_weights, is_fp16):
             assert scale_mode in ["single_scale", "per_channel_scale"]
 
-            def calc_low_and_range(input_, is_negative_range, is_fp16):
-                input_low = input_.min() - input_.mean() / 4
-                input_range = input_.max() - input_low
-                if is_negative_range:
-                    input_range *= -1
+            def calc_low_and_range(input_, is_fp16):
+                # Should generate input_low and input_range that cover only the internal
+                # 3/4 of the input data span to test the out-of-bounds gradient calculation
+                span = input_.max() - input_.min()
+                input_low = input_.min() + span / 8
+                input_range = span * 3 / 4
 
                 if is_fp16:
                     input_low = input_low.astype(np.float16)
@@ -270,7 +272,7 @@ class TestParametrized:
                 return input_low, input_range
 
             if scale_mode == "single_scale":
-                input_low, input_range = calc_low_and_range(input_, is_negative_range, is_fp16)
+                input_low, input_range = calc_low_and_range(input_, is_fp16)
                 return np.array([input_low]), np.array([input_range])
 
             if scale_mode == "per_channel_scale":
@@ -284,7 +286,7 @@ class TestParametrized:
                     input_range = np.zeros(scales_shape)
                     for idx in range(0, channel_count):
                         single_input_channel = input_[idx, ...]
-                        input_low[idx], input_range[idx] = calc_low_and_range(single_input_channel, is_negative_range,
+                        input_low[idx], input_range[idx] = calc_low_and_range(single_input_channel,
                                                                               is_fp16)
                 else:
                     channel_count = input_.shape[1]
@@ -296,8 +298,7 @@ class TestParametrized:
                     input_range = np.zeros(scales_shape)
                     for idx in range(0, channel_count):
                         single_input_channel = input_[:, idx, ...]
-                        input_low[0, idx], input_range[0, idx] = calc_low_and_range(single_input_channel,
-                                                                                    is_negative_range, is_fp16)
+                        input_low[0, idx], input_range[0, idx] = calc_low_and_range(single_input_channel, is_fp16)
 
                 return input_low, input_range
 
@@ -308,7 +309,7 @@ class TestParametrized:
             level_high = levels - 1
             return level_low, level_high, levels
 
-        def test_quantize_asymmetric_forward(self, _seed, input_size, bits, use_cuda, is_negative_range, is_weights,
+        def test_quantize_asymmetric_forward(self, _seed, input_size, bits, use_cuda, is_weights,
                                              is_fp16, scale_mode):
             skip_if_half_on_cpu(is_fp16, use_cuda)
             level_low, level_high, levels = self.get_range_level(bits)
@@ -316,7 +317,7 @@ class TestParametrized:
             if is_fp16:
                 ref_input = ref_input.astype(np.float16)
 
-            ref_input_low, ref_input_range = self.generate_range(ref_input, is_negative_range, scale_mode, is_weights,
+            ref_input_low, ref_input_range = self.generate_range(ref_input, scale_mode, is_weights,
                                                                  is_fp16)
             test_input, test_input_low, test_input_range = get_test_data(
                 [ref_input, ref_input_low, ref_input_range], use_cuda, is_fp16=is_fp16)
@@ -331,7 +332,7 @@ class TestParametrized:
 
             check_outputs_for_quantization_functions(ref_value, test_value, is_fp16)
 
-        def test_quantize_asymmetric_backward(self, _seed, input_size, bits, use_cuda, is_negative_range, is_weights,
+        def test_quantize_asymmetric_backward(self, _seed, input_size, bits, use_cuda, is_weights,
                                               is_fp16, scale_mode):
             skip_if_half_on_cpu(is_fp16, use_cuda)
             level_low, level_high, levels = self.get_range_level(bits)
@@ -339,7 +340,7 @@ class TestParametrized:
             if is_fp16:
                 ref_input = ref_input.astype(np.float16)
 
-            ref_input_low, ref_input_range = self.generate_range(ref_input, is_negative_range, scale_mode, is_weights,
+            ref_input_low, ref_input_range = self.generate_range(ref_input, scale_mode, is_weights,
                                                                  is_fp16)
             test_input, test_input_low, test_input_range = get_test_data(
                 [ref_input, ref_input_low, ref_input_range], use_cuda, is_backward=True, is_fp16=is_fp16)


### PR DESCRIPTION
An error was made during simultaneous work on the CUDA kernels way
back in time, and the per activation channel quantization kernel
ended up calculating gradients for lower bound of quantization
incorrectly when the currently quantized value was lower than this
lower bound. This slipped through the tests because they themselves
were too lax and had epsilon values set incommensurably high compared
to the quantized values. Fixed this - also removed the negative range
tests because they will actually always fail with the fixed test setup
due to TuneRange function that is built into AsymmetricQuantize automatically
resetting the negative input_range to positive values.