### PR TITLE
Use sequential sampling for evaluation across example scripts

### DIFF
--- a/examples/classification/main.py
+++ b/examples/classification/main.py
@@ -331,10 +331,12 @@ def create_data_loaders(config, train_dataset, val_dataset):
         batch_size //= config.ngpus_per_node
         workers //= config.ngpus_per_node
 
+    val_sampler = torch.utils.data.SequentialSampler(val_dataset)
     val_loader = torch.utils.data.DataLoader(
         val_dataset,
         batch_size=batch_size, shuffle=False,
-        num_workers=workers, pin_memory=pin_memory)
+        num_workers=workers, pin_memory=pin_memory,
+        sampler=val_sampler)
 
     train_sampler = None
     if config.distributed:

--- a/examples/object_detection/main.py
+++ b/examples/object_detection/main.py
@@ -210,7 +210,7 @@ def create_dataloaders(config):
     if config.distributed:
         test_sampler = DistributedSampler(test_dataset, config.rank, config.world_size)
     else:
-        test_sampler = None
+        test_sampler = torch.utils.data.SequentialSampler(test_dataset)
     test_data_loader = data.DataLoader(
         test_dataset, config.batch_size,
         num_workers=config.workers,

--- a/examples/semantic_segmentation/main.py
+++ b/examples/semantic_segmentation/main.py
@@ -182,9 +182,12 @@ def load_dataset(dataset, config):
         sampler=train_sampler, num_workers=num_workers,
         collate_fn=data_utils.collate_fn, drop_last=True)
 
+    val_sampler = torch.utils.data.SequentialSampler(val_set)
     val_loader = torch.utils.data.DataLoader(
         val_set,
         batch_size=1, num_workers=num_workers,
+        shuffle=False,
+        sampler=val_sampler,
         collate_fn=data_utils.collate_fn)
 
     # Get encoding between pixel values in label images and RGB colors


### PR DESCRIPTION
Hopefully this will make nightly compression training "eval" tests
more stable.