### PR TITLE
Set data loading workers to 0 across tests to force single process

### DIFF
--- a/nncf/quantization/quantizer_propagation.py
+++ b/nncf/quantization/quantizer_propagation.py
@@ -19,7 +19,6 @@ import networkx as nx
 import warnings
 from copy import deepcopy
 
-from more_itertools import consume
 
 from nncf.dynamic_graph.graph import OperationExecutionContext, NNCFGraph
 # pylint: disable=wildcard-import
@@ -541,7 +540,7 @@ class QuantizerPropagationStateGraph(nx.DiGraph):
                 continue
             curr_elt_iter = iter(group_pq_node_keys)
             next_elt_iter = iter(group_pq_node_keys)
-            consume(next_elt_iter, 1)
+            _ = next(next_elt_iter)  # in order not to use more_itertools.consume
             done = False
             while not done:
                 curr_pq_node_key = next(curr_elt_iter)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -210,6 +210,6 @@ def create_mock_dataloader(config, num_samples=1):
     input_sample_size = input_infos_list[0].shape
     data_loader = torch.utils.data.DataLoader(OnesDatasetMock(input_sample_size[1:], num_samples),
                                               batch_size=1,
-                                              num_workers=1,
+                                              num_workers=0, # Workaround
                                               shuffle=False)
     return data_loader

--- a/tests/quantization/test_quantization_helpers.py
+++ b/tests/quantization/test_quantization_helpers.py
@@ -77,7 +77,7 @@ def get_squeezenet_quantization_config(model_size=32, batch_size=3):
 
 def distributed_init_test_default(gpu, ngpus_per_node, config):
     config.batch_size = 3
-    config.workers = 3
+    config.workers = 0 #  workaround for the pytorch multiprocessingdataloader issue/
     config.gpu = gpu
     config.ngpus_per_node = ngpus_per_node
     config.rank = gpu
@@ -90,7 +90,7 @@ def distributed_init_test_default(gpu, ngpus_per_node, config):
     input_sample_size = input_infos_list[0].shape
     data_loader = torch.utils.data.DataLoader(RankDatasetMock(input_sample_size[1:], config.rank),
                                               batch_size=3,
-                                              num_workers=1,
+                                              num_workers=0, #  workaround
                                               shuffle=False)
     return data_loader
 

--- a/tests/quantization/test_scheduler.py
+++ b/tests/quantization/test_scheduler.py
@@ -167,7 +167,7 @@ def test_staged_scheduler_with_range_init():
     input_sample_size = input_infos_list[0].shape
     data_loader = DataLoader(OnesDatasetMock(input_sample_size[1:]),
                              batch_size=1,
-                             num_workers=1,
+                             num_workers=0, # Workaround for PyTorch MultiprocessingDataLoader issues
                              shuffle=False)
     config.register_extra_structs([QuantizationRangeInitArgs(data_loader)])
 
@@ -228,7 +228,7 @@ def test_staged_scheduler_with_hawq():
     input_sample_size = input_infos_list[0].shape
     data_loader = DataLoader(HawqDatasetMock(input_sample_size[1:], num_classes),
                              batch_size=1,
-                             num_workers=1,
+                             num_workers=0,  # Workaround for PyTorch MultiprocessingDataLoader issues
                              shuffle=False)
     criterion = nn.CrossEntropyLoss().cuda()
     config = register_default_init_args(config, data_loader, criterion)

--- a/tests/test_backward_compat.py
+++ b/tests/test_backward_compat.py
@@ -112,7 +112,7 @@ def test_loaded_model_evals_according_to_saved_acc(_params, tmp_path):
     args['config'] = str(config_path)
     args['mode'] = 'test'
     args['log-dir'] = tmp_path
-    args['workers'] = 4
+    args['workers'] = 0  # Workaroundr the PyTorch MultiProcessingDataLoader issue
     args['seed'] = 1
     args['resume'] = checkpoint_path
 

--- a/tests/test_compression_training.py
+++ b/tests/test_compression_training.py
@@ -226,7 +226,7 @@ def test_compression_train(_params, tmp_path):
 
     args['mode'] = 'train'
     args['log-dir'] = tmp_path
-    args['workers'] = 4
+    args['workers'] = 0  # Workaround for PyTorch MultiprocessingDataLoader issues
     args['seed'] = 1
 
     runner = Command(create_command_line(get_cli_dict_args(args), tc['sample_type']))
@@ -250,7 +250,7 @@ def test_compression_eval_trained(_params, tmp_path):
 
     args['mode'] = 'test'
     args['log-dir'] = tmp_path
-    args['workers'] = 4
+    args['workers'] = 0  # Workaround for PyTorch MultiprocessingDataLoader issues
     args['seed'] = 1
     checkpoint_path = os.path.join(args['checkpoint-save-dir'], tc['checkpoint_name'] + '_best.pth')
     args['resume'] = checkpoint_path

--- a/tests/test_sanity_sample.py
+++ b/tests/test_sanity_sample.py
@@ -214,7 +214,7 @@ def test_pretrained_model_eval(config, tmp_path, multiprocessing_distributed):
         "--config": config_factory.serialize(),
         "--log-dir": tmp_path,
         "--batch-size": config["batch_size"] * torch.cuda.device_count(),
-        "--workers": 1,
+        "--workers": 0, # Workaround for the PyTorch MultiProcessingDataLoader issue
     }
 
     if multiprocessing_distributed:
@@ -240,7 +240,7 @@ def test_pretrained_model_train(config, tmp_path, multiprocessing_distributed, c
         "--config": config_factory.serialize(),
         "--log-dir": tmp_path,
         "--batch-size": config["batch_size"] * torch.cuda.device_count(),
-        "--workers": 1,
+        "--workers": 0, # Workaround for the PyTorch MultiProcessingDataLoader issue
         "--epochs": 1,
         "--checkpoint-save-dir": checkpoint_save_dir,
         "--dist-url": "tcp://127.0.0.1:8989"
@@ -273,7 +273,7 @@ def test_trained_model_eval(config, tmp_path, multiprocessing_distributed, case_
         "--config": config_factory.serialize(),
         "--log-dir": tmp_path,
         "--batch-size": config["batch_size"] * torch.cuda.device_count(),
-        "--workers": 1,
+        "--workers": 0, # Workaround for the PyTorch MultiProcessingDataLoader issue
         "--weights": ckpt_path,
     }
 
@@ -308,7 +308,7 @@ def test_resume(config, tmp_path, multiprocessing_distributed, case_common_dirs)
         "--config": config_factory.serialize(),
         "--log-dir": tmp_path,
         "--batch-size": config["batch_size"] * torch.cuda.device_count(),
-        "--workers": 1,
+        "--workers": 0, # Workaround for the PyTorch MultiProcessingDataLoader issue
         "--epochs": 2,
         "--checkpoint-save-dir": checkpoint_save_dir,
         "--resume": ckpt_path,
@@ -394,7 +394,7 @@ def test_cpu_only_mode_produces_cpu_only_model(config, tmp_path, mocker):
         "--config": config_factory.serialize(),
         "--log-dir": tmp_path,
         "--batch-size": config["batch_size"] * torch.cuda.device_count(),
-        "--workers": 1,
+        "--workers": 0, # Workaround for the PyTorch MultiProcessingDataLoader issue
         "--epochs": 1,
         "--cpu-only": None
     }


### PR DESCRIPTION
Could fix the consequences of https://github.com/pytorch/pytorch/issues/39570