### PR TITLE
Return zero-valued torch.Tensor in CompressionLoss by default instead…

### DIFF
--- a/nncf/compression_method_api.py
+++ b/nncf/compression_method_api.py
@@ -46,7 +46,7 @@ class CompressionLoss(nn.Module):
         """
         Returns the compression loss value.
         """
-        return 0
+        return torch.zeros([])
 
     def statistics(self):
         """


### PR DESCRIPTION
… of int