### PR TITLE
Introduced `enabled` parameter to Quantizers

### DIFF
--- a/nncf/quantization/layers.py
+++ b/nncf/quantization/layers.py
@@ -98,7 +98,7 @@ class BaseQuantizer(nn.Module):
 
         self.levels = 0
 
-        self._is_enabled = True
+        self.register_buffer('enabled', torch.IntTensor([1]))
         self.initialized = False
         self.state_dict_name = None
         self.call_count = 0
@@ -134,14 +134,14 @@ class BaseQuantizer(nn.Module):
         raise NotImplementedError
 
     def is_enabled_quantization(self):
-        return self._is_enabled
+        return self.enabled[0] == 1
 
     def enable_quantization(self):
-        self._is_enabled = True
+        self.enabled[0] = 1
         self.enable_gradients()
 
     def disable_quantization(self):
-        self._is_enabled = False
+        self.enabled[0] = 0
         self.disable_gradients()
 
     def forward(self, x):

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -151,11 +151,13 @@ def check_equal(test, reference, rtol=1e-4):
 
 
 def create_compressed_model_and_algo_for_test(model: NNCFNetwork, config: NNCFConfig,
-                                              dummy_forward_fn: Callable[[Module], Any] = None) \
+                                              dummy_forward_fn: Callable[[Module], Any] = None,
+                                              resuming_state_dict: dict = None) \
     -> Tuple[NNCFNetwork, CompressionAlgorithmController]:
     assert isinstance(config, NNCFConfig)
     NNCFConfig.validate(config)
-    algo, model = create_compressed_model(model, config, dump_graphs=False, dummy_forward_fn=dummy_forward_fn)
+    algo, model = create_compressed_model(model, config, dump_graphs=False, dummy_forward_fn=dummy_forward_fn,
+                                          resuming_state_dict=resuming_state_dict)
     return model, algo
 
 


### PR DESCRIPTION
This is required to correctly export to ONNX a checkpoint from the staged quantization regardless of the specified config and scheduler.
